### PR TITLE
Move pthread.h from common.c to common.h

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -16,7 +16,6 @@
 #  include <uuid/uuid.h>
 #endif
 
-#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>

--- a/lib/common.h
+++ b/lib/common.h
@@ -8,6 +8,7 @@
 #ifndef __COMMON_H
 #define __COMMON_H
 
+#include <pthread.h>
 #include <stdint.h>      // uint_64_t
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
I have prepared a pull request for you to move the #include to the correct position. This fixes #2 

Could you please tag a new release after merging? Using HEAD is no option for me as I'm trying to get the PKGBUILD for Arch fixed (properly) and I need a tarball I can make my PKGBUILD automatically download.

Thanks in advance.