### PR TITLE
Python-Cleanup korrigiert: GIL vor Py_Finalize() anfordern

### DIFF
--- a/lib/python.c
+++ b/lib/python.c
@@ -223,7 +223,13 @@ int Python::initGlobal()
 
 void Python::exitGlobal()
 {
-	Py_Finalize();
+   // Re-acquire GIL before finalization (was released in initGlobal)
+   // but only if Python was actually initialized
+   if (Py_IsInitialized())
+   {
+      PyGILState_Ensure();
+      Py_Finalize();
+   }
 }
 
 //***************************************************************************


### PR DESCRIPTION
Ich habe leider die konkrete Fehlermeldung bzw, Coredump nicht mehr, aber durch diese Änderung wird ein Absturz beim Herunterfahren von epgd verhindert.
Getestet mit Ubuntu 24.04.3 LTS und yavdr