### PR TITLE
Minimal fix: parseIndex multi-field support only

### DIFF
--- a/lib/dbdict.c
+++ b/lib/dbdict.c
@@ -506,11 +506,14 @@ int cDbDict::parseIndex(const char* line)
          break;
       }
 
+      // Remove trailing comma from token (field separator)
       if (strchr(token, ','))
-      {
-         done = yes;
          *(strchr(token, ',')) = 0;
-      }
+
+      // Advance past comma in input string to allow parsing next field
+      // (getToken uses comma as default 'end' character and would fail)
+      while (*p && (*p == ',' || *p == ' '))
+         p++;
 
       if (i == idtName)
          index->setName(token);


### PR DESCRIPTION
In configs/epg.dat werden die Indices für die Tabellen unterschiedlich definiert, tlw. mit einem Komma als Trenner, tlw. nur mit Leerzeichen. Die Indices wurden nicht richtig angelegt, wenn ein Komma zwischen zwei Spalten verwendet wurde, da die Funktion lib/dbdict.c das Komma nur am Ende der Zeile erwartet hat, also nach dem ersten Komma die Verarbeitung abgebrochen hat.
Dies führt z.B. bei timersdone zu extrem langen Ladezeiten --> menu_timerListDone
Getestet mit Ubuntu 24.04.3 LTS und yavdr.