### PR TITLE
Fix: TheTVDB scraper updates only specific channel event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ http/epgd.full.js
 lib/pytst
 /Make.config
 tvdb
+.claude
+CLAUDE.md
+debian/
+build-package.sh

--- a/configs/thetvdbview.sql
+++ b/configs/thetvdbview.sql
@@ -1,6 +1,7 @@
 CREATE VIEW thetvdbview as
 select
  ev.eventid,
+ ev.channelid,
  case when ep.compname = 'TATORT' then concat('Tatort',replace(substring(ep.extracol1,11),' und ',' & ')) else ep.episodename end title,
  ev.scrsp,
  case when ep.compname = 'TATORT' then Null else ep.season end season,
@@ -18,6 +19,7 @@ where
 union
 select
  eventid,
+ channelid,
  title,
  scrsp,
  case when substring(shorttext,1,1)='S' and substring(shorttext,2,1) REGEXP ('[0-9]') then TRIM(LEADING '0' from replace(SUBSTRING_INDEX(shorttext, 'E', 1),'S','')) end  season,

--- a/tvdbmanager.h
+++ b/tvdbmanager.h
@@ -29,6 +29,7 @@ class cTVDBManager
       struct SeriesLookupData
       {
          tEventId eventId {0};
+         std::string channelId;
          std::string title;
          int lastScraped {0};
          int season {0};
@@ -96,6 +97,6 @@ class cTVDBManager
       int LoadEpisode(const std::string& name, int seriesId);
       int lookupEpisodeId(int seriesID, const SeriesLookupData& lookupData);
 
-      void UpdateEvent(tEventId eventID, int seriesID, int episodeID);
+      void UpdateEvent(tEventId eventID, const char* channelID, int seriesID, int episodeID);
       void DeleteSeries(int seriesId);
 };


### PR DESCRIPTION
## Summary

- `UpdateEvent()` only used `eventid` in the WHERE clause
- Events with same eventid on different channels received identical series data
- This caused wrong series associations (e.g., event on channel A got series data meant for channel B)

## Changes

- Add `channelid` to `thetvdbview` SQL view (both UNION parts)
- Add `channelId` field to `SeriesLookupData` struct
- Include `channelid` in `updateEvent` WHERE clause
- Pass `channelid` through `getSeriesWithEpisodesFromEPG` and `processSeries`

## Test plan

- [ ] Verify TheTVDB scraper updates only the event on the correct channel
- [ ] Check that events on other channels with same eventid are not affected

🤖 Generated with [Claude Code](https://claude.ai/code)