### PR TITLE
Fix: Add channelid to timer-event JOIN condition

### DIFF
--- a/httpd.c
+++ b/httpd.c
@@ -857,7 +857,7 @@ int cEpgHttpd::initDb()
    selectAllTimer->clrBindPrefix();
    selectAllTimer->build(" from %s t left outer join %s e",
                          timerDb->TableName(), "eventsviewplain");
-   selectAllTimer->build(" on (t.eventid = e.cnt_useid) and e.updflg in (%s)", cEventState::getVisible());
+   selectAllTimer->build(" on (t.eventid = e.cnt_useid and t.channelid = e.cnt_channelid) and e.updflg in (%s)", cEventState::getVisible());
    // selectAllTimer->build(" where ");
    // selectAllTimer->bindInChar("t", "STATE", &timerIncState);
    // selectAllTimer->bindInChar("t", "STATE", &timerExcState, " and not ");


### PR DESCRIPTION
## Summary

- `selectAllTimer` query joined timers with events using only `eventid`
- Different channels can have events with the same `eventid`
- This caused wrong event titles to be displayed in the timer list

## Changes

- Add `channelid` to the JOIN condition in `selectAllTimer` statement
- Changed: `on (t.eventid = e.cnt_useid)` 
- To: `on (t.eventid = e.cnt_useid and t.channelid = e.cnt_channelid)`

## Test plan

- [ ] Verify timer list shows correct titles for each timer
- [ ] Check that timers don't show titles from events on different channels

🤖 Generated with [Claude Code](https://claude.ai/code)